### PR TITLE
changing root level redirect to point back to giving.cu.edu/essentialcu

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,16 @@ module.exports = {
     return [
       {
         source: "/",
+        destination: "https://giving.cu.edu/essentialcu/",
+        permanent: false,
+      },
+      {
+        source: "/impact",
+        destination: "/impact-reports/onward",
+        permanent: true,
+      },
+      {
+        source: "/impact-reports",
         destination: "/impact-reports/onward",
         permanent: true,
       },


### PR DESCRIPTION
This redirect needs to be added before we can point the essential.cu.edu subdomain DNS at https://essential-cu-herokuapp-com.global.ssl.fastly.net
